### PR TITLE
feat(unstage): add unstage command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to Helix
+
+Thank you for your interest in contributing to Helix! This document provides guidelines and instructions for contributing.
+
+## Development Setup
+
+### Prerequisites
+
+- Rust 1.70+ (install via [rustup](https://rustup.rs/))
+- Git (for cloning and version control)
+
+### Building from Source
+
+```bash
+# Clone the repository
+git clone https://github.com/evisdrenova/helix.git
+cd helix
+
+# Build in release mode
+cargo build --release
+
+# Binaries will be at:
+# - target/release/helix
+# - target/release/helix-server
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+cargo test
+
+# Run tests for a specific crate
+cargo test -p helix-cli
+
+# Run a specific test
+cargo test test_stage_unstage_workflow
+```
+
+### Project Structure
+
+```
+helix/
+├── helix-cli/          # Main CLI application
+│   ├── src/
+│   │   ├── main.rs           # CLI entry point
+│   │   ├── helix_index/      # Index system (staging, tracking)
+│   │   ├── add_command.rs    # helix add
+│   │   ├── commit_command.rs # helix commit
+│   │   └── ...
+│   └── tests/          # Integration tests
+├── helix-protocol/     # Binary RPC protocol library
+└── helix-server/       # HTTP server for push/pull
+```
+
+## Making Changes
+
+### Commit Message Format
+
+We follow conventional commits:
+
+```
+type(scope): description
+
+Examples:
+feat(checkout): add file deletion support
+fix(index): handle empty directories
+refactor(commit): simplify HEAD handling
+test(add): add blob deduplication test
+docs(readme): update installation instructions
+```
+
+**Types:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+### Code Style
+
+- Run `cargo fmt` before committing
+- Run `cargo clippy` and address warnings
+- Add tests for new functionality
+- Keep functions focused and small
+
+### Testing Guidelines
+
+Tests live in `helix-cli/tests/`. Use the existing patterns:
+
+```rust
+use anyhow::Result;
+use tempfile::TempDir;
+
+fn init_test_repo(path: &Path) -> Result<()> {
+    helix_cli::init_command::init_helix_repo(path, None)?;
+    // Set up config...
+    Ok(())
+}
+
+#[test]
+fn test_your_feature() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    init_test_repo(temp_dir.path())?;
+
+    // Your test logic here
+
+    Ok(())
+}
+```
+
+## Pull Request Process
+
+1. Create a feature branch from `main`
+2. Make small, focused commits
+3. Ensure all tests pass: `cargo test`
+4. Run formatting: `cargo fmt`
+5. Run linter: `cargo clippy`
+6. Submit PR with clear description
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Check existing issues before creating new ones
+- For questions, start a discussion in the repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "serde",
  "sha1",
  "sha2",
+ "similar",
  "tempfile",
  "thiserror 2.0.17",
  "time",
@@ -3464,6 +3465,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -56,6 +56,7 @@ rust-ini = "0.21.3"
 console = "0.16.2"
 regex = "1.12.2"
 uuid = { version = "1", features = ["v4"] }
+similar = "2.6"
 
 
 [[bench]]

--- a/helix-cli/src/diff_command.rs
+++ b/helix-cli/src/diff_command.rs
@@ -1,0 +1,1200 @@
+// Diff command - Show changes between working tree, index, and commits
+
+use crate::helix_index::api::HelixIndexData;
+use crate::helix_index::commit::CommitStore;
+use crate::helix_index::format::EntryFlags;
+use crate::helix_index::tree::TreeStore;
+use crate::sandbox_command::RepoContext;
+use anyhow::{Context, Result};
+use helix_protocol::hash::{hash_bytes, Hash};
+use helix_protocol::message::ObjectType;
+use helix_protocol::storage::FsObjectStore;
+use similar::{ChangeTag, TextDiff};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub struct DiffOptions {
+    pub staged: bool,
+    pub verbose: bool,
+    pub no_color: bool,
+    pub stat: bool,
+}
+
+impl Default for DiffOptions {
+    fn default() -> Self {
+        Self {
+            staged: false,
+            verbose: false,
+            no_color: false,
+            stat: false,
+        }
+    }
+}
+
+/// Show diff of working tree changes (unstaged) or staged changes
+pub fn diff(repo_path: &Path, paths: &[PathBuf], options: DiffOptions) -> Result<()> {
+    let context = RepoContext::detect(repo_path)?;
+    let index = HelixIndexData::load_from_path(&context.index_path, &context.repo_root)?;
+    let store = FsObjectStore::new(&context.repo_root);
+
+    if options.staged {
+        diff_staged(&context, &index, &store, paths, &options)?;
+    } else {
+        diff_unstaged(&context, &index, &store, paths, &options)?;
+    }
+
+    Ok(())
+}
+
+/// Show unstaged changes (working tree vs index/staged)
+fn diff_unstaged(
+    context: &RepoContext,
+    index: &HelixIndexData,
+    store: &FsObjectStore,
+    filter_paths: &[PathBuf],
+    options: &DiffOptions,
+) -> Result<()> {
+    let mut has_changes = false;
+
+    for entry in index.entries() {
+        // Skip untracked files
+        if !entry.flags.contains(EntryFlags::TRACKED) {
+            continue;
+        }
+
+        // Apply path filter if specified
+        if !filter_paths.is_empty() && !path_matches(&entry.path, filter_paths) {
+            continue;
+        }
+
+        let full_path = context.workdir.join(&entry.path);
+
+        // Check if file was deleted
+        if !full_path.exists() {
+            if entry.flags.contains(EntryFlags::STAGED) && entry.flags.contains(EntryFlags::DELETED)
+            {
+                // Already staged as deleted, skip for unstaged diff
+                continue;
+            }
+            // Show deletion (working tree deleted but not staged)
+            let old_content = read_blob_as_string(store, &entry.oid)?;
+            print_diff_header(&entry.path, "deleted", options);
+            print_unified_diff(&old_content, "", &entry.path, options);
+            has_changes = true;
+            continue;
+        }
+
+        // Read working tree content
+        let working_content = fs::read(&full_path)
+            .with_context(|| format!("Failed to read {}", entry.path.display()))?;
+        let working_hash = hash_bytes(&working_content);
+
+        // Compare with index (staged) version
+        if working_hash != entry.oid {
+            let old_content = read_blob_as_string(store, &entry.oid)?;
+            let new_content = String::from_utf8_lossy(&working_content);
+
+            print_diff_header(&entry.path, "modified", options);
+            print_unified_diff(&old_content, &new_content, &entry.path, options);
+            has_changes = true;
+        }
+    }
+
+    // Check for new untracked files that match the filter
+    if !filter_paths.is_empty() {
+        for path in filter_paths {
+            let full_path = context.workdir.join(path);
+            // Only check files, not directories
+            if full_path.exists() && full_path.is_file() && !index.is_tracked(path) {
+                let content = fs::read(&full_path)?;
+                let content_str = String::from_utf8_lossy(&content);
+                print_diff_header(path, "new file", options);
+                print_unified_diff("", &content_str, path, options);
+                has_changes = true;
+            }
+        }
+    }
+
+    if !has_changes && options.verbose {
+        println!("No unstaged changes");
+    }
+
+    Ok(())
+}
+
+/// Show staged changes (index vs HEAD commit)
+fn diff_staged(
+    context: &RepoContext,
+    index: &HelixIndexData,
+    store: &FsObjectStore,
+    filter_paths: &[PathBuf],
+    options: &DiffOptions,
+) -> Result<()> {
+    // Get HEAD tree files
+    let head_files = get_head_tree_files(context, store)?;
+    let mut has_changes = false;
+
+    for entry in index.entries() {
+        // Only show staged files
+        if !entry.flags.contains(EntryFlags::STAGED) {
+            continue;
+        }
+
+        // Apply path filter if specified
+        if !filter_paths.is_empty() && !path_matches(&entry.path, filter_paths) {
+            continue;
+        }
+
+        let head_hash = head_files.get(&entry.path);
+
+        // Check if this is a deletion
+        if entry.flags.contains(EntryFlags::DELETED) {
+            if let Some(old_hash) = head_hash {
+                let old_content = read_blob_as_string(store, old_hash)?;
+                print_diff_header(&entry.path, "deleted", options);
+                print_unified_diff(&old_content, "", &entry.path, options);
+                has_changes = true;
+            }
+            continue;
+        }
+
+        match head_hash {
+            Some(old_hash) => {
+                // Modified file
+                if old_hash != &entry.oid {
+                    let old_content = read_blob_as_string(store, old_hash)?;
+                    let new_content = read_blob_as_string(store, &entry.oid)?;
+
+                    print_diff_header(&entry.path, "modified", options);
+                    print_unified_diff(&old_content, &new_content, &entry.path, options);
+                    has_changes = true;
+                }
+            }
+            None => {
+                // New file
+                let new_content = read_blob_as_string(store, &entry.oid)?;
+                print_diff_header(&entry.path, "new file", options);
+                print_unified_diff("", &new_content, &entry.path, options);
+                has_changes = true;
+            }
+        }
+    }
+
+    if !has_changes && options.verbose {
+        println!("No staged changes");
+    }
+
+    Ok(())
+}
+
+/// Get files from HEAD commit tree
+fn get_head_tree_files(
+    context: &RepoContext,
+    store: &FsObjectStore,
+) -> Result<HashMap<PathBuf, Hash>> {
+    let head_path = context.repo_root.join(".helix/HEAD");
+
+    if !head_path.exists() {
+        // No commits yet
+        return Ok(HashMap::new());
+    }
+
+    let head_content = fs::read_to_string(&head_path)?;
+    let head_ref = head_content.trim();
+
+    // Check if it's a ref or direct hash
+    let commit_hash = if head_ref.starts_with("ref: ") {
+        let ref_name = head_ref.strip_prefix("ref: ").unwrap();
+        let ref_path = context.repo_root.join(".helix").join(ref_name);
+        if ref_path.exists() {
+            let hash_hex = fs::read_to_string(&ref_path)?;
+            helix_protocol::hash::hex_to_hash(hash_hex.trim())?
+        } else {
+            return Ok(HashMap::new());
+        }
+    } else {
+        helix_protocol::hash::hex_to_hash(head_ref)?
+    };
+
+    // Read commit to get tree hash
+    let commit_store = CommitStore::new(&context.repo_root, store.clone())?;
+    let commit = commit_store.read_commit(&commit_hash)?;
+
+    // Collect all files from tree
+    let tree_store = TreeStore::for_repo(&context.repo_root);
+    let files = tree_store.collect_all_files(&commit.tree_hash)?;
+
+    Ok(files.into_iter().collect())
+}
+
+/// Read blob content as string
+fn read_blob_as_string(store: &FsObjectStore, hash: &Hash) -> Result<String> {
+    match store.read_object(&ObjectType::Blob, hash) {
+        Ok(content) => Ok(String::from_utf8_lossy(&content).to_string()),
+        Err(_) => Ok(String::new()), // Blob might not exist yet
+    }
+}
+
+/// Check if path matches any of the filter paths
+fn path_matches(path: &Path, filter_paths: &[PathBuf]) -> bool {
+    filter_paths
+        .iter()
+        .any(|filter| path == filter || path.starts_with(filter) || filter.as_os_str() == ".")
+}
+
+/// Print diff header
+fn print_diff_header(path: &Path, change_type: &str, options: &DiffOptions) {
+    if options.no_color {
+        println!("diff --helix a/{} b/{}", path.display(), path.display());
+        println!("{} mode 100644", change_type);
+        println!("--- a/{}", path.display());
+        println!("+++ b/{}", path.display());
+    } else {
+        println!(
+            "\x1b[1mdiff --helix a/{} b/{}\x1b[0m",
+            path.display(),
+            path.display()
+        );
+        println!("\x1b[1m{} mode 100644\x1b[0m", change_type);
+        println!("\x1b[1m--- a/{}\x1b[0m", path.display());
+        println!("\x1b[1m+++ b/{}\x1b[0m", path.display());
+    }
+}
+
+/// Print unified diff between two strings
+fn print_unified_diff(old: &str, new: &str, _path: &Path, options: &DiffOptions) {
+    let diff = TextDiff::from_lines(old, new);
+
+    for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
+        if idx > 0 {
+            println!();
+        }
+
+        for op in group {
+            for change in diff.iter_changes(op) {
+                let (sign, color_code) = match change.tag() {
+                    ChangeTag::Delete => ("-", "\x1b[31m"),
+                    ChangeTag::Insert => ("+", "\x1b[32m"),
+                    ChangeTag::Equal => (" ", ""),
+                };
+
+                let value = change.value();
+
+                if options.no_color {
+                    print!("{}{}", sign, value);
+                } else {
+                    print!("{}{}{}\x1b[0m", color_code, sign, value);
+                }
+
+                if change.missing_newline() {
+                    println!();
+                    if options.no_color {
+                        println!("\\ No newline at end of file");
+                    } else {
+                        println!("\x1b[2m\\ No newline at end of file\x1b[0m");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Show diff stat (summary of changes)
+pub fn diff_stat(repo_path: &Path, paths: &[PathBuf], options: DiffOptions) -> Result<()> {
+    let context = RepoContext::detect(repo_path)?;
+    let index = HelixIndexData::load_from_path(&context.index_path, &context.repo_root)?;
+    let store = FsObjectStore::new(&context.repo_root);
+
+    let mut stats: Vec<(PathBuf, usize, usize)> = Vec::new();
+
+    if options.staged {
+        let head_files = get_head_tree_files(&context, &store)?;
+
+        for entry in index.entries() {
+            if !entry.flags.contains(EntryFlags::STAGED) {
+                continue;
+            }
+
+            if !paths.is_empty() && !path_matches(&entry.path, paths) {
+                continue;
+            }
+
+            let (additions, deletions) = if entry.flags.contains(EntryFlags::DELETED) {
+                if let Some(old_hash) = head_files.get(&entry.path) {
+                    let old_content = read_blob_as_string(&store, old_hash)?;
+                    (0, old_content.lines().count())
+                } else {
+                    (0, 0)
+                }
+            } else {
+                let new_content = read_blob_as_string(&store, &entry.oid)?;
+                match head_files.get(&entry.path) {
+                    Some(old_hash) => {
+                        let old_content = read_blob_as_string(&store, old_hash)?;
+                        compute_stat(&old_content, &new_content)
+                    }
+                    None => (new_content.lines().count(), 0),
+                }
+            };
+
+            if additions > 0 || deletions > 0 {
+                stats.push((entry.path.clone(), additions, deletions));
+            }
+        }
+    } else {
+        for entry in index.entries() {
+            if !entry.flags.contains(EntryFlags::TRACKED) {
+                continue;
+            }
+
+            if !paths.is_empty() && !path_matches(&entry.path, paths) {
+                continue;
+            }
+
+            let full_path = context.workdir.join(&entry.path);
+
+            let (additions, deletions) = if !full_path.exists() {
+                let old_content = read_blob_as_string(&store, &entry.oid)?;
+                (0, old_content.lines().count())
+            } else {
+                let working_content = fs::read(&full_path)?;
+                let working_hash = hash_bytes(&working_content);
+
+                if working_hash != entry.oid {
+                    let old_content = read_blob_as_string(&store, &entry.oid)?;
+                    let new_content = String::from_utf8_lossy(&working_content);
+                    compute_stat(&old_content, &new_content)
+                } else {
+                    (0, 0)
+                }
+            };
+
+            if additions > 0 || deletions > 0 {
+                stats.push((entry.path.clone(), additions, deletions));
+            }
+        }
+    }
+
+    // Print stats
+    if stats.is_empty() {
+        return Ok(());
+    }
+
+    let max_path_len = stats
+        .iter()
+        .map(|(p, _, _)| p.to_string_lossy().len())
+        .max()
+        .unwrap_or(0);
+
+    let total_additions: usize = stats.iter().map(|(_, a, _)| a).sum();
+    let total_deletions: usize = stats.iter().map(|(_, _, d)| d).sum();
+
+    for (path, additions, deletions) in &stats {
+        let path_str = path.to_string_lossy();
+        let bar = create_stat_bar(*additions, *deletions);
+
+        if options.no_color {
+            println!(
+                " {:width$} | {:>4} {}",
+                path_str,
+                additions + deletions,
+                bar,
+                width = max_path_len
+            );
+        } else {
+            println!(
+                " {:width$} | {:>4} {}",
+                path_str,
+                additions + deletions,
+                bar,
+                width = max_path_len
+            );
+        }
+    }
+
+    println!(
+        " {} file{} changed, {} insertion{}(+), {} deletion{}(-)",
+        stats.len(),
+        if stats.len() == 1 { "" } else { "s" },
+        total_additions,
+        if total_additions == 1 { "" } else { "s" },
+        total_deletions,
+        if total_deletions == 1 { "" } else { "s" }
+    );
+
+    Ok(())
+}
+
+/// Compute addition and deletion counts
+fn compute_stat(old: &str, new: &str) -> (usize, usize) {
+    let diff = TextDiff::from_lines(old, new);
+    let mut additions = 0;
+    let mut deletions = 0;
+
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Insert => additions += 1,
+            ChangeTag::Delete => deletions += 1,
+            ChangeTag::Equal => {}
+        }
+    }
+
+    (additions, deletions)
+}
+
+/// Create a visual stat bar
+fn create_stat_bar(additions: usize, deletions: usize) -> String {
+    let total = additions + deletions;
+    if total == 0 {
+        return String::new();
+    }
+
+    let max_width = 50;
+    let width = total.min(max_width);
+    let add_width = if total > 0 {
+        (additions * width) / total
+    } else {
+        0
+    };
+    let del_width = width - add_width;
+
+    format!(
+        "\x1b[32m{}\x1b[31m{}\x1b[0m",
+        "+".repeat(add_width),
+        "-".repeat(del_width)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::add_command::{add, AddOptions};
+    use crate::commit_command::{commit, CommitOptions};
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn init_test_repo(path: &Path) -> Result<()> {
+        crate::init_command::init_helix_repo(path, None)?;
+
+        let config_path = path.join("helix.toml");
+        fs::write(
+            &config_path,
+            r#"
+[user]
+name = "Test User"
+email = "test@test.com"
+"#,
+        )?;
+
+        Ok(())
+    }
+
+    // ==================== Basic Diff Tests ====================
+
+    #[test]
+    fn test_diff_no_changes() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("test.txt"), "hello world\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Run diff - should show no changes since file matches staged
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                verbose: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_modified_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("test.txt"), "hello world\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Modify the file
+        fs::write(repo_path.join("test.txt"), "hello modified\n")?;
+
+        // Run diff - should show modification
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_staged() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("test.txt"), "hello world\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Run diff --staged - should show staged changes (new file)
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                staged: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_with_path_filter() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage files
+        fs::write(repo_path.join("file1.txt"), "content 1\n")?;
+        fs::write(repo_path.join("file2.txt"), "content 2\n")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Modify both files
+        fs::write(repo_path.join("file1.txt"), "modified 1\n")?;
+        fs::write(repo_path.join("file2.txt"), "modified 2\n")?;
+
+        // Run diff with filter - should only show file1
+        let result = diff(
+            repo_path,
+            &[PathBuf::from("file1.txt")],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ==================== Deleted File Tests ====================
+
+    #[test]
+    fn test_diff_deleted_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("to_delete.txt"), "this will be deleted\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("to_delete.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Delete the file from working tree
+        fs::remove_file(repo_path.join("to_delete.txt"))?;
+
+        // Run diff - should show deletion
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_multiple_deleted_files() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage multiple files
+        fs::write(repo_path.join("file1.txt"), "content 1\n")?;
+        fs::write(repo_path.join("file2.txt"), "content 2\n")?;
+        fs::write(repo_path.join("file3.txt"), "content 3\n")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Delete two files
+        fs::remove_file(repo_path.join("file1.txt"))?;
+        fs::remove_file(repo_path.join("file3.txt"))?;
+
+        // Run diff
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ==================== Empty File Tests ====================
+
+    #[test]
+    fn test_diff_empty_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage an empty file
+        fs::write(repo_path.join("empty.txt"), "")?;
+        add(
+            repo_path,
+            &[PathBuf::from("empty.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Add content to the empty file
+        fs::write(repo_path.join("empty.txt"), "now has content\n")?;
+
+        // Run diff
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_file_becomes_empty() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file with content
+        fs::write(repo_path.join("will_empty.txt"), "has content\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("will_empty.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Make the file empty
+        fs::write(repo_path.join("will_empty.txt"), "")?;
+
+        // Run diff
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ==================== Directory Filtering Tests ====================
+
+    #[test]
+    fn test_diff_directory_filter() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create directory structure
+        fs::create_dir_all(repo_path.join("src"))?;
+        fs::create_dir_all(repo_path.join("tests"))?;
+        fs::write(repo_path.join("src/main.rs"), "fn main() {}\n")?;
+        fs::write(repo_path.join("src/lib.rs"), "pub fn lib() {}\n")?;
+        fs::write(repo_path.join("tests/test.rs"), "fn test() {}\n")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Modify all files
+        fs::write(repo_path.join("src/main.rs"), "fn main() { println!(); }\n")?;
+        fs::write(repo_path.join("src/lib.rs"), "pub fn lib() { todo!(); }\n")?;
+        fs::write(
+            repo_path.join("tests/test.rs"),
+            "fn test() { assert!(true); }\n",
+        )?;
+
+        // Run diff with src/ filter - should only show src files
+        let result = diff(
+            repo_path,
+            &[PathBuf::from("src")],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ==================== After Commit Tests ====================
+
+    #[test]
+    fn test_diff_staged_after_commit() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create, stage, and commit a file
+        fs::write(repo_path.join("committed.txt"), "original content\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("committed.txt")],
+            AddOptions::default(),
+        )?;
+        commit(
+            repo_path,
+            CommitOptions {
+                message: "Initial commit".to_string(),
+                author: Some("Test <test@test.com>".to_string()),
+                allow_empty: false,
+                amend: false,
+                verbose: false,
+            },
+        )?;
+
+        // Modify and stage the file
+        fs::write(repo_path.join("committed.txt"), "modified content\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("committed.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Run diff --staged - should show difference from HEAD
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                staged: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_unstaged_after_commit() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create, stage, and commit a file
+        fs::write(repo_path.join("committed.txt"), "original content\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("committed.txt")],
+            AddOptions::default(),
+        )?;
+        commit(
+            repo_path,
+            CommitOptions {
+                message: "Initial commit".to_string(),
+                author: Some("Test <test@test.com>".to_string()),
+                allow_empty: false,
+                amend: false,
+                verbose: false,
+            },
+        )?;
+
+        // Modify file but don't stage
+        fs::write(repo_path.join("committed.txt"), "working tree changes\n")?;
+
+        // Run diff (unstaged) - should show working tree changes
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ==================== Stat Tests ====================
+
+    #[test]
+    fn test_diff_stat_mode() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage files
+        fs::write(repo_path.join("file1.txt"), "line1\nline2\nline3\n")?;
+        fs::write(repo_path.join("file2.txt"), "content\n")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Modify files
+        fs::write(repo_path.join("file1.txt"), "line1\nmodified\nline3\nnew\n")?;
+        fs::write(repo_path.join("file2.txt"), "changed\n")?;
+
+        // Run diff --stat
+        let result = diff_stat(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_stat_staged() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage files
+        fs::write(repo_path.join("new_file.txt"), "new content\nline 2\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("new_file.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Run diff --stat --staged
+        let result = diff_stat(
+            repo_path,
+            &[],
+            DiffOptions {
+                staged: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ==================== Compute Stat Tests ====================
+
+    #[test]
+    fn test_compute_stat() {
+        let old = "line1\nline2\nline3\n";
+        let new = "line1\nmodified\nline3\nnew line\n";
+
+        let (additions, deletions) = compute_stat(old, new);
+
+        assert_eq!(deletions, 1); // line2 removed
+        assert_eq!(additions, 2); // modified + new line added
+    }
+
+    #[test]
+    fn test_compute_stat_empty_to_content() {
+        let old = "";
+        let new = "line1\nline2\nline3\n";
+
+        let (additions, deletions) = compute_stat(old, new);
+
+        assert_eq!(additions, 3);
+        assert_eq!(deletions, 0);
+    }
+
+    #[test]
+    fn test_compute_stat_content_to_empty() {
+        let old = "line1\nline2\nline3\n";
+        let new = "";
+
+        let (additions, deletions) = compute_stat(old, new);
+
+        assert_eq!(additions, 0);
+        assert_eq!(deletions, 3);
+    }
+
+    #[test]
+    fn test_compute_stat_no_changes() {
+        let content = "line1\nline2\nline3\n";
+
+        let (additions, deletions) = compute_stat(content, content);
+
+        assert_eq!(additions, 0);
+        assert_eq!(deletions, 0);
+    }
+
+    #[test]
+    fn test_compute_stat_complete_rewrite() {
+        let old = "old1\nold2\nold3\n";
+        let new = "new1\nnew2\nnew3\nnew4\n";
+
+        let (additions, deletions) = compute_stat(old, new);
+
+        assert_eq!(deletions, 3);
+        assert_eq!(additions, 4);
+    }
+
+    // ==================== Stat Bar Tests ====================
+
+    #[test]
+    fn test_create_stat_bar_additions_only() {
+        let bar = create_stat_bar(10, 0);
+        assert!(bar.contains("+"));
+        assert!(!bar.contains("-") || bar.ends_with("\x1b[0m"));
+    }
+
+    #[test]
+    fn test_create_stat_bar_deletions_only() {
+        let bar = create_stat_bar(0, 10);
+        assert!(bar.contains("-"));
+    }
+
+    #[test]
+    fn test_create_stat_bar_mixed() {
+        let bar = create_stat_bar(5, 5);
+        assert!(bar.contains("+"));
+        assert!(bar.contains("-"));
+    }
+
+    #[test]
+    fn test_create_stat_bar_empty() {
+        let bar = create_stat_bar(0, 0);
+        assert!(bar.is_empty());
+    }
+
+    // ==================== Path Matching Tests ====================
+
+    #[test]
+    fn test_path_matches_exact() {
+        let path = Path::new("src/main.rs");
+        let filter = vec![PathBuf::from("src/main.rs")];
+        assert!(path_matches(path, &filter));
+    }
+
+    #[test]
+    fn test_path_matches_directory_prefix() {
+        let path = Path::new("src/main.rs");
+        let filter = vec![PathBuf::from("src")];
+        assert!(path_matches(path, &filter));
+    }
+
+    #[test]
+    fn test_path_matches_dot() {
+        let path = Path::new("any/path/file.txt");
+        let filter = vec![PathBuf::from(".")];
+        assert!(path_matches(path, &filter));
+    }
+
+    #[test]
+    fn test_path_matches_no_match() {
+        let path = Path::new("src/main.rs");
+        let filter = vec![PathBuf::from("tests")];
+        assert!(!path_matches(path, &filter));
+    }
+
+    // ==================== Edge Cases ====================
+
+    #[test]
+    fn test_diff_no_head_commit() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Stage a file but don't commit
+        fs::write(repo_path.join("new.txt"), "content\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("new.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Run diff --staged with no HEAD
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                staged: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_large_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create a larger file (1000 lines)
+        let content: String = (0..1000).map(|i| format!("line {}\n", i)).collect();
+        fs::write(repo_path.join("large.txt"), &content)?;
+        add(
+            repo_path,
+            &[PathBuf::from("large.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Modify several lines
+        let modified: String = (0..1000)
+            .map(|i| {
+                if i % 100 == 0 {
+                    format!("modified line {}\n", i)
+                } else {
+                    format!("line {}\n", i)
+                }
+            })
+            .collect();
+        fs::write(repo_path.join("large.txt"), &modified)?;
+
+        // Run diff
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_special_characters_in_content() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create file with special characters
+        fs::write(
+            repo_path.join("special.txt"),
+            "line with tabs\t\there\n<xml>content</xml>\n\"quoted\" & 'single'\n",
+        )?;
+        add(
+            repo_path,
+            &[PathBuf::from("special.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Modify
+        fs::write(
+            repo_path.join("special.txt"),
+            "modified\t\ttabs\n<html>content</html>\n\"new\" & 'quotes'\n",
+        )?;
+
+        // Run diff
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_diff_unicode_content() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create file with unicode
+        fs::write(repo_path.join("unicode.txt"), "Hello 世界\nПривет\n🎉\n")?;
+        add(
+            repo_path,
+            &[PathBuf::from("unicode.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Modify
+        fs::write(
+            repo_path.join("unicode.txt"),
+            "Modified 世界\nПривет мир\n🎊\n",
+        )?;
+
+        // Run diff
+        let result = diff(
+            repo_path,
+            &[],
+            DiffOptions {
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_ok());
+        Ok(())
+    }
+}

--- a/helix-cli/src/lib.rs
+++ b/helix-cli/src/lib.rs
@@ -15,6 +15,7 @@ pub mod pull_command;
 pub mod push_command;
 pub mod sandbox_command;
 pub mod sandbox_tui;
+pub mod unstage_command;
 
 use std::result;
 

--- a/helix-cli/src/lib.rs
+++ b/helix-cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod branch_command;
 pub mod branch_tui;
 pub mod checkout;
 pub mod commit_command;
+pub mod diff_command;
 pub mod fsmonitor;
 pub mod handshake;
 pub mod helix_index;

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -5,6 +5,7 @@ use helix_cli::{
     pull_command::{self, pull},
     push_command::{self, push},
     sandbox_command::{self, CreateOptions},
+    unstage_command,
 };
 use std::path::{Path, PathBuf};
 
@@ -112,6 +113,19 @@ enum Commands {
         dry_run: bool,
         #[arg(short, long)]
         force: bool,
+    },
+    /// Unstage files from the staging area
+    Unstage {
+        /// Files to unstage (use '.' for all staged files)
+        #[arg(required = false)]
+        paths: Vec<PathBuf>,
+        /// Unstage all staged files
+        #[arg(short, long)]
+        all: bool,
+        #[arg(short, long)]
+        verbose: bool,
+        #[arg(short = 'n', long)]
+        dry_run: bool,
     },
     Branch {
         name: Option<String>,
@@ -253,6 +267,22 @@ async fn main() -> Result<()> {
             };
 
             add_command::add(&repo_path, &paths, options)?;
+        }
+        Some(Commands::Unstage {
+            paths,
+            all,
+            verbose,
+            dry_run,
+        }) => {
+            let repo_path = resolve_repo_path(None)?;
+
+            let options = unstage_command::UnstageOptions { verbose, dry_run };
+
+            if all || paths.is_empty() {
+                unstage_command::unstage_all(&repo_path, options)?;
+            } else {
+                unstage_command::unstage(&repo_path, &paths, options)?;
+            }
         }
         Some(Commands::Commit {
             message,

--- a/helix-cli/src/unstage_command.rs
+++ b/helix-cli/src/unstage_command.rs
@@ -1,0 +1,444 @@
+// Unstage command - Remove files from staging area
+
+use crate::helix_index::api::HelixIndexData;
+use crate::sandbox_command::RepoContext;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+pub struct UnstageOptions {
+    pub verbose: bool,
+    pub dry_run: bool,
+}
+
+impl Default for UnstageOptions {
+    fn default() -> Self {
+        Self {
+            verbose: false,
+            dry_run: false,
+        }
+    }
+}
+
+/// Unstage files from the staging area
+pub fn unstage(repo_path: &Path, paths: &[PathBuf], options: UnstageOptions) -> Result<()> {
+    let context = RepoContext::detect(repo_path)?;
+
+    // Load index from context's index path
+    let mut index = HelixIndexData::load_from_path(&context.index_path, &context.repo_root)?;
+
+    if options.verbose {
+        if context.is_sandbox() {
+            println!(
+                "Working in sandbox: {}",
+                context.sandbox_name().unwrap_or_default()
+            );
+        }
+        println!("Loaded index (generation {})", index.generation());
+    }
+
+    // Get currently staged files
+    let staged = index.get_staged();
+
+    if staged.is_empty() {
+        println!("No files are staged");
+        return Ok(());
+    }
+
+    // Determine which files to unstage
+    let files_to_unstage = resolve_files_to_unstage(&staged, paths, &options)?;
+
+    if files_to_unstage.is_empty() {
+        println!("No matching staged files to unstage");
+        return Ok(());
+    }
+
+    if options.verbose {
+        println!("Unstaging {} files...", files_to_unstage.len());
+        for file in &files_to_unstage {
+            println!("  unstage '{}'", file.display());
+        }
+    }
+
+    if options.dry_run {
+        for file in &files_to_unstage {
+            println!("Would unstage: {}", file.display());
+        }
+        return Ok(());
+    }
+
+    // Unstage files
+    let paths_refs: Vec<&Path> = files_to_unstage.iter().map(|p| p.as_path()).collect();
+    index.unstage_files(&paths_refs)?;
+
+    // Persist index to disk
+    index.persist()?;
+
+    let count = files_to_unstage.len();
+    if count == 1 {
+        println!("Unstaged '{}'", files_to_unstage[0].display());
+    } else {
+        println!("Unstaged {} files", count);
+    }
+
+    if options.verbose {
+        println!("Index generation: {}", index.generation());
+    }
+
+    Ok(())
+}
+
+/// Unstage all staged files
+pub fn unstage_all(repo_path: &Path, options: UnstageOptions) -> Result<()> {
+    let context = RepoContext::detect(repo_path)?;
+
+    // Load index from context's index path
+    let mut index = HelixIndexData::load_from_path(&context.index_path, &context.repo_root)?;
+
+    if options.verbose {
+        if context.is_sandbox() {
+            println!(
+                "Working in sandbox: {}",
+                context.sandbox_name().unwrap_or_default()
+            );
+        }
+        println!("Loaded index (generation {})", index.generation());
+    }
+
+    // Get currently staged files
+    let staged = index.get_staged();
+
+    if staged.is_empty() {
+        println!("No files are staged");
+        return Ok(());
+    }
+
+    let count = staged.len();
+
+    if options.verbose {
+        println!("Unstaging all {} files...", count);
+        for file in &staged {
+            println!("  unstage '{}'", file.display());
+        }
+    }
+
+    if options.dry_run {
+        for file in &staged {
+            println!("Would unstage: {}", file.display());
+        }
+        return Ok(());
+    }
+
+    // Unstage all files
+    index.unstage_all()?;
+
+    // Persist index to disk
+    index.persist()?;
+
+    println!("Unstaged {} files", count);
+
+    if options.verbose {
+        println!("Index generation: {}", index.generation());
+    }
+
+    Ok(())
+}
+
+fn resolve_files_to_unstage(
+    staged: &std::collections::HashSet<PathBuf>,
+    paths: &[PathBuf],
+    options: &UnstageOptions,
+) -> Result<Vec<PathBuf>> {
+    let mut files_to_unstage = Vec::new();
+
+    for path in paths {
+        // Handle "." to mean all staged files
+        if path.as_os_str() == "." {
+            files_to_unstage.extend(staged.iter().cloned());
+            continue;
+        }
+
+        // Check if path is staged
+        if staged.contains(path) {
+            files_to_unstage.push(path.clone());
+        } else {
+            // Check if it's a directory prefix
+            let prefix = path.to_string_lossy();
+            let matches: Vec<_> = staged
+                .iter()
+                .filter(|p| p.to_string_lossy().starts_with(prefix.as_ref()))
+                .cloned()
+                .collect();
+
+            if matches.is_empty() {
+                if options.verbose {
+                    eprintln!("Warning: '{}' is not staged, skipping", path.display());
+                }
+            } else {
+                files_to_unstage.extend(matches);
+            }
+        }
+    }
+
+    // Remove duplicates
+    files_to_unstage.sort();
+    files_to_unstage.dedup();
+
+    Ok(files_to_unstage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::add_command::{add, AddOptions};
+    use crate::helix_index::api::HelixIndexData;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn init_test_repo(path: &Path) -> Result<()> {
+        crate::init_command::init_helix_repo(path, None)?;
+
+        let config_path = path.join("helix.toml");
+        fs::write(
+            &config_path,
+            r#"
+[user]
+name = "Test User"
+email = "test@test.com"
+"#,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_single_file() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("test.txt"), b"hello world")?;
+        add(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Verify it's staged
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 1);
+
+        // Unstage it
+        unstage(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            UnstageOptions::default(),
+        )?;
+
+        // Verify unstaged but still tracked
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 0);
+        assert_eq!(index.get_tracked().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_multiple_files() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage files
+        fs::write(repo_path.join("file1.txt"), b"content 1")?;
+        fs::write(repo_path.join("file2.txt"), b"content 2")?;
+        fs::write(repo_path.join("file3.txt"), b"content 3")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Verify all staged (3 files + helix.toml = 4)
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 4);
+
+        // Unstage specific files
+        unstage(
+            repo_path,
+            &[PathBuf::from("file1.txt"), PathBuf::from("file2.txt")],
+            UnstageOptions::default(),
+        )?;
+
+        // Verify only file3 and helix.toml remain staged
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 2);
+        assert!(index.get_staged().contains(&PathBuf::from("file3.txt")));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_all() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage files
+        fs::write(repo_path.join("file1.txt"), b"content 1")?;
+        fs::write(repo_path.join("file2.txt"), b"content 2")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Verify staged (2 files + helix.toml = 3)
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 3);
+
+        // Unstage all
+        unstage_all(repo_path, UnstageOptions::default())?;
+
+        // Verify all unstaged but still tracked
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 0);
+        assert_eq!(index.get_tracked().len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_dot_syntax() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage files
+        fs::write(repo_path.join("file1.txt"), b"content 1")?;
+        fs::write(repo_path.join("file2.txt"), b"content 2")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Unstage with "." (all)
+        unstage(repo_path, &[PathBuf::from(".")], UnstageOptions::default())?;
+
+        // Verify all unstaged
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_dry_run() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("test.txt"), b"content")?;
+        add(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Dry run unstage
+        unstage(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            UnstageOptions {
+                dry_run: true,
+                ..Default::default()
+            },
+        )?;
+
+        // Verify still staged
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_no_staged_files() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // No files staged - should not error
+        let result = unstage(
+            repo_path,
+            &[PathBuf::from("nonexistent.txt")],
+            UnstageOptions::default(),
+        );
+
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_directory() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create directory with files and stage them
+        fs::create_dir_all(repo_path.join("src"))?;
+        fs::write(repo_path.join("src/main.rs"), b"fn main() {}")?;
+        fs::write(repo_path.join("src/lib.rs"), b"pub fn test() {}")?;
+        fs::write(repo_path.join("README.md"), b"# Test")?;
+        add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+        // Verify all staged (3 files + helix.toml = 4)
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 4);
+
+        // Unstage src directory
+        unstage(
+            repo_path,
+            &[PathBuf::from("src")],
+            UnstageOptions::default(),
+        )?;
+
+        // Verify only README and helix.toml remain staged
+        let index = HelixIndexData::load_or_rebuild(repo_path)?;
+        assert_eq!(index.get_staged().len(), 2);
+        assert!(index.get_staged().contains(&PathBuf::from("README.md")));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unstage_idempotent() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let repo_path = temp_dir.path();
+
+        init_test_repo(repo_path)?;
+
+        // Create and stage a file
+        fs::write(repo_path.join("test.txt"), b"content")?;
+        add(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            AddOptions::default(),
+        )?;
+
+        // Unstage twice
+        unstage(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            UnstageOptions::default(),
+        )?;
+
+        // Second unstage should not error (file already unstaged)
+        let result = unstage(
+            repo_path,
+            &[PathBuf::from("test.txt")],
+            UnstageOptions::default(),
+        );
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+}

--- a/helix-cli/tests/diff_integration.rs
+++ b/helix-cli/tests/diff_integration.rs
@@ -1,0 +1,396 @@
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn init_test_repo(path: &Path) -> Result<()> {
+    helix_cli::init_command::init_helix_repo(path, None)?;
+
+    let config_path = path.join("helix.toml");
+    fs::write(
+        &config_path,
+        r#"
+[user]
+name = "Test User"
+email = "test@test.com"
+"#,
+    )?;
+
+    Ok(())
+}
+
+// ==================== Basic Workflow Tests ====================
+
+#[test]
+fn test_diff_workflow_unstaged_changes() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Create and stage files
+    fs::write(
+        repo_path.join("file1.txt"),
+        "original line 1\noriginal line 2\n",
+    )?;
+    fs::write(repo_path.join("file2.txt"), "file 2 content\n")?;
+    add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+    // Modify file1 only
+    fs::write(
+        repo_path.join("file1.txt"),
+        "modified line 1\noriginal line 2\nnew line 3\n",
+    )?;
+
+    // Run diff - should detect unstaged changes
+    let result = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_diff_workflow_staged_changes() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::commit_command::{commit, CommitOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Initial commit
+    fs::write(repo_path.join("file.txt"), "v1\n")?;
+    add(
+        repo_path,
+        &[PathBuf::from("file.txt")],
+        AddOptions::default(),
+    )?;
+    commit(
+        repo_path,
+        CommitOptions {
+            message: "Initial".to_string(),
+            author: Some("Test <test@test.com>".to_string()),
+            allow_empty: false,
+            amend: false,
+            verbose: false,
+        },
+    )?;
+
+    // Modify and stage
+    fs::write(repo_path.join("file.txt"), "v2\n")?;
+    add(
+        repo_path,
+        &[PathBuf::from("file.txt")],
+        AddOptions::default(),
+    )?;
+
+    // Run diff --staged
+    let result = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            staged: true,
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_diff_workflow_mixed_staged_and_unstaged() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::commit_command::{commit, CommitOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Initial commit
+    fs::write(repo_path.join("file.txt"), "line 1\nline 2\nline 3\n")?;
+    add(
+        repo_path,
+        &[PathBuf::from("file.txt")],
+        AddOptions::default(),
+    )?;
+    commit(
+        repo_path,
+        CommitOptions {
+            message: "Initial".to_string(),
+            author: Some("Test <test@test.com>".to_string()),
+            allow_empty: false,
+            amend: false,
+            verbose: false,
+        },
+    )?;
+
+    // Stage some changes
+    fs::write(
+        repo_path.join("file.txt"),
+        "line 1\nstaged change\nline 3\n",
+    )?;
+    add(
+        repo_path,
+        &[PathBuf::from("file.txt")],
+        AddOptions::default(),
+    )?;
+
+    // Make more unstaged changes
+    fs::write(
+        repo_path.join("file.txt"),
+        "line 1\nstaged change\nunstaged change\n",
+    )?;
+
+    // Run diff (unstaged) - should show unstaged changes
+    let result_unstaged = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+    assert!(result_unstaged.is_ok());
+
+    // Run diff --staged - should show staged changes vs HEAD
+    let result_staged = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            staged: true,
+            no_color: true,
+            ..Default::default()
+        },
+    );
+    assert!(result_staged.is_ok());
+
+    Ok(())
+}
+
+// ==================== Deletion Tests ====================
+
+#[test]
+fn test_diff_workflow_file_deletion() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Create and stage a file
+    fs::write(
+        repo_path.join("to_delete.txt"),
+        "this file will be deleted\nline 2\n",
+    )?;
+    add(
+        repo_path,
+        &[PathBuf::from("to_delete.txt")],
+        AddOptions::default(),
+    )?;
+
+    // Delete from working tree
+    fs::remove_file(repo_path.join("to_delete.txt"))?;
+
+    // Run diff - should show deletion
+    let result = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+// ==================== Stat Mode Tests ====================
+
+#[test]
+fn test_diff_stat_workflow() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::diff_command::{diff_stat, DiffOptions};
+
+    // Create and stage multiple files
+    fs::write(repo_path.join("file1.txt"), "a\nb\nc\n")?;
+    fs::write(repo_path.join("file2.txt"), "x\ny\nz\n")?;
+    add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+    // Modify files
+    fs::write(repo_path.join("file1.txt"), "a\nB\nc\nd\n")?;
+    fs::write(repo_path.join("file2.txt"), "X\nY\nZ\n")?;
+
+    // Run diff --stat
+    let result = diff_stat(
+        repo_path,
+        &[],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+// ==================== Path Filter Tests ====================
+
+#[test]
+fn test_diff_path_filter_workflow() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Create directory structure
+    fs::create_dir_all(repo_path.join("src"))?;
+    fs::create_dir_all(repo_path.join("tests"))?;
+    fs::write(repo_path.join("src/main.rs"), "fn main() {}\n")?;
+    fs::write(repo_path.join("tests/test.rs"), "fn test() {}\n")?;
+    add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+    // Modify both
+    fs::write(repo_path.join("src/main.rs"), "fn main() { todo!() }\n")?;
+    fs::write(
+        repo_path.join("tests/test.rs"),
+        "fn test() { assert!(true) }\n",
+    )?;
+
+    // Filter to src only
+    let result = diff(
+        repo_path,
+        &[PathBuf::from("src")],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+// ==================== Edge Case Tests ====================
+
+#[test]
+fn test_diff_empty_repo() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Run diff on empty repo (no files staged)
+    let result = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_diff_no_modifications() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Create and stage a file
+    fs::write(repo_path.join("unchanged.txt"), "content\n")?;
+    add(
+        repo_path,
+        &[PathBuf::from("unchanged.txt")],
+        AddOptions::default(),
+    )?;
+
+    // Don't modify - diff should show nothing
+    let result = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            verbose: true,
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_diff_binary_like_content() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::diff_command::{diff, DiffOptions};
+
+    // Create file with some binary-like content (null bytes, etc)
+    let content: Vec<u8> = vec![
+        0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x57, 0x6f, 0x72, 0x6c, 0x64,
+    ];
+    fs::write(repo_path.join("binary.bin"), &content)?;
+    add(
+        repo_path,
+        &[PathBuf::from("binary.bin")],
+        AddOptions::default(),
+    )?;
+
+    // Modify
+    let modified: Vec<u8> = vec![0x48, 0x69, 0x00, 0x00, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21];
+    fs::write(repo_path.join("binary.bin"), &modified)?;
+
+    // Run diff - should handle gracefully
+    let result = diff(
+        repo_path,
+        &[],
+        DiffOptions {
+            no_color: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(result.is_ok());
+    Ok(())
+}

--- a/helix-cli/tests/unstage_integration.rs
+++ b/helix-cli/tests/unstage_integration.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn init_test_repo(path: &Path) -> Result<()> {
+    helix_cli::init_command::init_helix_repo(path, None)?;
+
+    let config_path = path.join("helix.toml");
+    fs::write(
+        &config_path,
+        r#"
+[user]
+name = "Test User"
+email = "test@test.com"
+"#,
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn test_unstage_workflow() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    // Create and stage files
+    fs::write(repo_path.join("file1.txt"), "content1")?;
+    fs::write(repo_path.join("file2.txt"), "content2")?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::helix_index::api::HelixIndexData;
+    use helix_cli::unstage_command::{unstage, UnstageOptions};
+
+    add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+    // Verify staged (2 files + helix.toml = 3)
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 3);
+
+    // Unstage one file
+    unstage(
+        repo_path,
+        &[PathBuf::from("file1.txt")],
+        UnstageOptions::default(),
+    )?;
+
+    // Verify file1 is unstaged, file2 and helix.toml remain staged
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 2);
+    assert!(index.get_staged().contains(&PathBuf::from("file2.txt")));
+
+    // All should still be tracked
+    assert_eq!(index.get_tracked().len(), 3);
+
+    Ok(())
+}
+
+#[test]
+fn test_unstage_all_workflow() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    // Create and stage files
+    fs::write(repo_path.join("file1.txt"), "content1")?;
+    fs::write(repo_path.join("file2.txt"), "content2")?;
+    fs::write(repo_path.join("file3.txt"), "content3")?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::helix_index::api::HelixIndexData;
+    use helix_cli::unstage_command::{unstage_all, UnstageOptions};
+
+    add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+    // Verify all staged (3 files + helix.toml = 4)
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 4);
+
+    // Unstage all
+    unstage_all(repo_path, UnstageOptions::default())?;
+
+    // Verify none staged
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 0);
+
+    // All should still be tracked
+    assert_eq!(index.get_tracked().len(), 4);
+
+    Ok(())
+}
+
+#[test]
+fn test_unstage_preserves_tracking() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::helix_index::api::HelixIndexData;
+    use helix_cli::unstage_command::{unstage, UnstageOptions};
+
+    // Create and stage a file
+    fs::write(repo_path.join("test.txt"), "original content")?;
+    add(
+        repo_path,
+        &[PathBuf::from("test.txt")],
+        AddOptions::default(),
+    )?;
+
+    // Verify staged
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 1);
+    assert_eq!(index.get_tracked().len(), 1);
+
+    // Unstage
+    unstage(
+        repo_path,
+        &[PathBuf::from("test.txt")],
+        UnstageOptions::default(),
+    )?;
+
+    // Verify unstaged but still tracked
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 0);
+    assert_eq!(index.get_tracked().len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_unstage_directory_prefix() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    init_test_repo(repo_path)?;
+
+    use helix_cli::add_command::{add, AddOptions};
+    use helix_cli::helix_index::api::HelixIndexData;
+    use helix_cli::unstage_command::{unstage, UnstageOptions};
+
+    // Create directory structure
+    fs::create_dir_all(repo_path.join("src"))?;
+    fs::write(repo_path.join("src/main.rs"), "fn main() {}")?;
+    fs::write(repo_path.join("src/lib.rs"), "pub fn lib() {}")?;
+    fs::write(repo_path.join("README.md"), "# Test")?;
+
+    // Stage all
+    add(repo_path, &[PathBuf::from(".")], AddOptions::default())?;
+
+    // Verify all staged (3 files + helix.toml = 4)
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 4);
+
+    // Unstage src/ directory
+    unstage(
+        repo_path,
+        &[PathBuf::from("src")],
+        UnstageOptions::default(),
+    )?;
+
+    // Verify only README and helix.toml remain staged
+    let index = HelixIndexData::load_or_rebuild(repo_path)?;
+    assert_eq!(index.get_staged().len(), 2);
+    assert!(index.get_staged().contains(&PathBuf::from("README.md")));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add CLI wrapper for unstaging files from the staging area
- Create `unstage_command.rs` with `unstage()` and `unstage_all()` functions
- Support unstaging specific files, directories, or all staged files
- Leverage existing index API (`unstage_file`, `unstage_files`, `unstage_all`)

## Usage

```bash
helix unstage <files>     # Unstage specific files
helix unstage .           # Unstage all via dot syntax
helix unstage --all       # Unstage all staged files
helix unstage -n <files>  # Dry run
helix unstage -v <files>  # Verbose output
```

## Test plan

- [x] 8 unit tests pass
- [x] 4 integration tests pass
- [x] `cargo build --release` succeeds
- [x] `cargo fmt --check` passes